### PR TITLE
Refactor project structure to clean architecture

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/data/local/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/local/FavoritesRepository.kt
@@ -1,4 +1,0 @@
-package com.example.tibiaclone.data.local
-
-class FavoritesRepository {
-}

--- a/app/src/main/java/com/example/tibiaclone/data/remote/api/PokemonApi.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/remote/api/PokemonApi.kt
@@ -1,6 +1,6 @@
-package com.example.tibiaclone.data.network
+package com.example.tibiaclone.data.remote.api
 
-import com.example.tibiaclone.data.model.Pokemon
+import com.example.tibiaclone.domain.model.Pokemon
 import retrofit2.http.GET
 import retrofit2.http.Path
 

--- a/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
@@ -1,0 +1,7 @@
+package com.example.tibiaclone.data.repository
+
+import com.example.tibiaclone.domain.repository.FavoritesRepository
+
+class FavoritesRepositoryImpl : FavoritesRepository {
+    // TODO: implement favorites persistence using DataStore or Room
+}

--- a/app/src/main/java/com/example/tibiaclone/data/repository/PokemonRepositoryImpl.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/repository/PokemonRepositoryImpl.kt
@@ -1,23 +1,24 @@
-package com.example.tibiaclone.data.network
+package com.example.tibiaclone.data.repository
 
 import android.util.Log
-import com.example.tibiaclone.data.model.Pokemon
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.data.remote.api.PokemonApi
 import javax.inject.Inject
 
-class PokemonRepository @Inject constructor(private val pokemonApi: PokemonApi) {
+class PokemonRepositoryImpl @Inject constructor(private val pokemonApi: PokemonApi) : com.example.tibiaclone.domain.repository.PokemonRepository {
 
     private val pokemonCache = mutableMapOf<Int, Pokemon>();
 
-    suspend fun getPokemon(id: Int): Pokemon {
+    override suspend fun getPokemon(id: Int): Pokemon {
         return this.pokemonApi.getPokemonById(id);
     }
 
-    fun getPokemonFromCache(id: Int?): Pokemon? {
+    override fun getPokemonFromCache(id: Int?): Pokemon? {
         return pokemonCache[id];
     }
 
 
-    suspend fun getListOfPokemons(quantity:Int): List<Pokemon> {
+    override suspend fun getListOfPokemons(quantity:Int): List<Pokemon> {
         val list = mutableListOf<Pokemon>();
         for (i in 1..quantity) {
             try {
@@ -34,7 +35,7 @@ class PokemonRepository @Inject constructor(private val pokemonApi: PokemonApi) 
         return list;
     }
 
-    suspend fun getFirst20Pokemons(): List<Pokemon> {
+    override suspend fun getFirst20Pokemons(): List<Pokemon> {
         val list = mutableListOf<Pokemon>();
         for (i in 1..20) {
             try {

--- a/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
@@ -1,9 +1,12 @@
-package com.example.tibiaclone.data.network
+package com.example.tibiaclone.di
 
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import com.example.tibiaclone.data.remote.api.PokemonApi
+import com.example.tibiaclone.data.repository.PokemonRepositoryImpl
+import com.example.tibiaclone.domain.repository.PokemonRepository
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -11,7 +14,7 @@ import javax.inject.Singleton
 @Module //This class will provide objects
 @InstallIn(SingletonComponent::class)
 
-object RetrofitInstance {
+object NetworkModule {
 
     @Provides
     @Singleton
@@ -24,6 +27,6 @@ object RetrofitInstance {
     @Provides
     @Singleton
     fun providePokemonRepository(pokemonApi: PokemonApi): PokemonRepository {
-        return PokemonRepository(pokemonApi)
+        return PokemonRepositoryImpl(pokemonApi)
     }
 }

--- a/app/src/main/java/com/example/tibiaclone/domain/model/Pokemon.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/model/Pokemon.kt
@@ -1,6 +1,6 @@
-package com.example.tibiaclone.data.model
+package com.example.tibiaclone.domain.model
 
-import PokemonType
+import com.example.tibiaclone.domain.model.PokemonType
 
 data class Pokemon(
     val id: Int,

--- a/app/src/main/java/com/example/tibiaclone/domain/model/PokemonType.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/model/PokemonType.kt
@@ -1,3 +1,5 @@
+package com.example.tibiaclone.domain.model
+
 import com.google.gson.annotations.SerializedName
 
 enum class PokemonType {

--- a/app/src/main/java/com/example/tibiaclone/domain/model/fake/FakePokemon.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/model/fake/FakePokemon.kt
@@ -1,6 +1,6 @@
-package com.example.tibiaclone.data.model.fake
+package com.example.tibiaclone.domain.model.fake
 
-import com.example.tibiaclone.data.model.*
+import com.example.tibiaclone.domain.model.*
 
 val fakePokemon = Pokemon(
     id = 1,

--- a/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
@@ -1,0 +1,5 @@
+package com.example.tibiaclone.domain.repository
+
+interface FavoritesRepository {
+    // TODO: define methods for managing favorites
+}

--- a/app/src/main/java/com/example/tibiaclone/domain/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/repository/PokemonRepository.kt
@@ -1,0 +1,10 @@
+package com.example.tibiaclone.domain.repository
+
+import com.example.tibiaclone.domain.model.Pokemon
+
+interface PokemonRepository {
+    suspend fun getPokemon(id: Int): Pokemon
+    fun getPokemonFromCache(id: Int?): Pokemon?
+    suspend fun getListOfPokemons(quantity: Int): List<Pokemon>
+    suspend fun getFirst20Pokemons(): List<Pokemon>
+}

--- a/app/src/main/java/com/example/tibiaclone/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/navigation/AppNavHost.kt
@@ -9,7 +9,7 @@ import androidx.navigation.navArgument
 import androidx.navigation.NavHostController
 import com.example.tibiaclone.ui.screens.home.HomeScreen
 import com.example.tibiaclone.ui.screens.details.DetailsScreen
-import com.example.tibiaclone.viewmodel.HomeViewModel
+import com.example.tibiaclone.ui.viewmodel.HomeViewModel
 
 @Composable
 fun AppNavHost(navController: NavHostController) {

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
@@ -1,6 +1,6 @@
 package com.example.tibiaclone.ui.screens.details
 
-import PokemonType
+import com.example.tibiaclone.domain.model.PokemonType
 import android.annotation.SuppressLint
 import android.media.MediaPlayer
 import android.text.Layout
@@ -42,11 +42,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import coil.compose.AsyncImage
 import com.example.tibiaclone.R
-import com.example.tibiaclone.data.model.Pokemon
+import com.example.tibiaclone.domain.model.Pokemon
 import com.example.tibiaclone.ui.theme.SetStatusBarColor
 import com.example.tibiaclone.utils.getPokemonBackgroundColor
 import com.example.tibiaclone.utils.getPrettyRemoteSprites
-import com.example.tibiaclone.viewmodel.DetailViewModel
+import com.example.tibiaclone.ui.viewmodel.DetailViewModel
 import com.example.tibiaclone.utils.*;
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/home/HomeScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import com.example.tibiaclone.viewmodel.HomeViewModel
+import com.example.tibiaclone.ui.viewmodel.HomeViewModel
 import androidx.compose.runtime.getValue
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.SideEffect

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
@@ -1,6 +1,6 @@
 package com.example.tibiaclone.ui.screens.home
 
-import PokemonType
+import com.example.tibiaclone.domain.model.PokemonType
 import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import com.example.tibiaclone.R
-import com.example.tibiaclone.data.model.Pokemon
+import com.example.tibiaclone.domain.model.Pokemon
 import com.example.tibiaclone.utils.getPokemonBackgroundColor
 import com.example.tibiaclone.utils.getPrettyRemoteSprites
 

--- a/app/src/main/java/com/example/tibiaclone/ui/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/viewmodel/DetailViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.tibiaclone.viewmodel
+package com.example.tibiaclone.ui.viewmodel
 
 import android.media.MediaPlayer
 import androidx.compose.runtime.mutableStateOf
@@ -8,8 +8,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.example.tibiaclone.R
-import com.example.tibiaclone.data.model.Pokemon
-import com.example.tibiaclone.data.network.PokemonRepository
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.repository.PokemonRepository
 import com.example.tibiaclone.data.statics.memesSounds
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/tibiaclone/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/viewmodel/HomeViewModel.kt
@@ -1,11 +1,11 @@
-package com.example.tibiaclone.viewmodel
+package com.example.tibiaclone.ui.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.tibiaclone.data.model.Pokemon
-import com.example.tibiaclone.data.model.fake.fakePokemon
-import com.example.tibiaclone.data.network.PokemonRepository
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.model.fake.fakePokemon
+import com.example.tibiaclone.domain.repository.PokemonRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/tibiaclone/utils/ColorsByType.kt
+++ b/app/src/main/java/com/example/tibiaclone/utils/ColorsByType.kt
@@ -2,7 +2,8 @@ package com.example.tibiaclone.utils
 
 import android.util.Log
 import androidx.compose.ui.graphics.Color
-import com.example.tibiaclone.data.model.Pokemon
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.model.PokemonType
 
 
 fun getPokemonBackgroundColor(pokemon: Pokemon): Color {


### PR DESCRIPTION
## Summary
- migrate model classes to a new `domain` package
- introduce `domain.repository` interfaces
- move API and repository implementations under `data`
- create a Hilt `NetworkModule`
- move view models to `ui.viewmodel`
- update imports after refactor

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841e11670bc832e9ba1fdde65d78624