### PR TITLE
Introduce network DTO for Pokemon

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/data/remote/api/PokemonApi.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/remote/api/PokemonApi.kt
@@ -1,6 +1,6 @@
 package com.example.tibiaclone.data.remote.api
 
-import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.data.remote.model.PokemonDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -8,8 +8,8 @@ import retrofit2.http.Path
 
 interface PokemonApi {
     @GET("pokemon/{id}")
-    suspend fun getPokemonById(@Path("id") id:Int): Pokemon
+    suspend fun getPokemonById(@Path("id") id:Int): PokemonDto
 
     @GET("pokemon/{name}")
-    suspend fun getPokemonByName(@Path("name") name:String): Pokemon
+    suspend fun getPokemonByName(@Path("name") name:String): PokemonDto
 }

--- a/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonDto.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonDto.kt
@@ -1,0 +1,62 @@
+package com.example.tibiaclone.data.remote.model
+
+import com.example.tibiaclone.domain.model.PokemonType
+
+data class PokemonDto(
+    val id: Int,
+    val name: String,
+    val height: Int,
+    val weight: Int,
+    val sprites: SpritesDto,
+    val types: List<PokemonTypeSlotDto>,
+    val stats: List<PokemonStatDto>,
+    val base_experience: Int,
+    val cries: CriesDto,
+    val abilities: List<PokemonAbilityDto>,
+    val gender_rate: Int,
+    val hatch_counter: Int,
+    val egg_groups: List<EggGroupDto>
+)
+
+data class CriesDto(
+    val latest: String,
+    val legacy: String
+)
+
+data class SpritesDto(
+    val front_default: String
+)
+
+data class PokemonTypeSlotDto(
+    val slot: Int,
+    val type: TypeInfoDto
+)
+
+data class TypeInfoDto(
+    val name: PokemonType
+)
+
+data class PokemonStatDto(
+    val base_stat: Int,
+    val stat: StatInfoDto
+)
+
+data class StatInfoDto(
+    val name: String
+)
+
+data class PokemonAbilityDto(
+    val ability: AbilityInfoDto,
+    val is_hidden: Boolean,
+    val slot: Int
+)
+
+data class AbilityInfoDto(
+    val name: String,
+    val url: String
+)
+
+data class EggGroupDto(
+    val name: String,
+    val url: String
+)

--- a/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonMapper.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonMapper.kt
@@ -1,0 +1,24 @@
+package com.example.tibiaclone.data.remote.model
+
+import com.example.tibiaclone.domain.model.Cries
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.model.Stat
+
+/**
+ * Maps [PokemonDto] coming from the network into the domain [Pokemon] model.
+ */
+fun PokemonDto.toPokemon(): Pokemon = Pokemon(
+    id = id,
+    name = name,
+    height = height,
+    weight = weight,
+    imageUrl = sprites.front_default,
+    types = types.map { it.type.name },
+    stats = stats.map { Stat(it.stat.name, it.base_stat) },
+    baseExperience = base_experience,
+    cries = Cries(latest = cries.latest, legacy = cries.legacy),
+    abilities = abilities.map { it.ability.name },
+    genderRate = gender_rate,
+    hatchCounter = hatch_counter,
+    eggGroups = egg_groups.map { it.name }
+)

--- a/app/src/main/java/com/example/tibiaclone/data/repository/PokemonRepositoryImpl.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/repository/PokemonRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.example.tibiaclone.data.repository
 import android.util.Log
 import com.example.tibiaclone.domain.model.Pokemon
 import com.example.tibiaclone.data.remote.api.PokemonApi
+import com.example.tibiaclone.data.remote.model.toPokemon
 import javax.inject.Inject
 
 class PokemonRepositoryImpl @Inject constructor(private val pokemonApi: PokemonApi) : com.example.tibiaclone.domain.repository.PokemonRepository {
@@ -10,7 +11,7 @@ class PokemonRepositoryImpl @Inject constructor(private val pokemonApi: PokemonA
     private val pokemonCache = mutableMapOf<Int, Pokemon>();
 
     override suspend fun getPokemon(id: Int): Pokemon {
-        return this.pokemonApi.getPokemonById(id);
+        return pokemonApi.getPokemonById(id).toPokemon()
     }
 
     override fun getPokemonFromCache(id: Int?): Pokemon? {
@@ -22,7 +23,7 @@ class PokemonRepositoryImpl @Inject constructor(private val pokemonApi: PokemonA
         val list = mutableListOf<Pokemon>();
         for (i in 1..quantity) {
             try {
-                val pokemon = this.pokemonApi.getPokemonById(i);
+                val pokemon = pokemonApi.getPokemonById(i).toPokemon()
                 list.add(pokemon)
             } catch (error: Exception) {
                 error.printStackTrace()
@@ -39,7 +40,7 @@ class PokemonRepositoryImpl @Inject constructor(private val pokemonApi: PokemonA
         val list = mutableListOf<Pokemon>();
         for (i in 1..20) {
             try {
-                val pokemon = this.pokemonApi.getPokemonById(i);
+                val pokemon = pokemonApi.getPokemonById(i).toPokemon()
                 list.add(pokemon)
             } catch (error: Exception) {
                 error.printStackTrace()

--- a/app/src/main/java/com/example/tibiaclone/domain/model/Pokemon.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/model/Pokemon.kt
@@ -1,60 +1,32 @@
 package com.example.tibiaclone.domain.model
 
-import com.example.tibiaclone.domain.model.PokemonType
+/**
+ * Domain model used across the application. It contains only the data that the
+ * UI actually needs and is decoupled from the network response structure.
+ */
 
 data class Pokemon(
     val id: Int,
     val name: String,
     val height: Int,
     val weight: Int,
-    val sprites: Sprites,
-    val types: List<PokemonTypeSlot>,
-    val stats: List<PokemonStat>,
-    val base_experience: Int,
+    val imageUrl: String,
+    val types: List<PokemonType>,
+    val stats: List<Stat>,
+    val baseExperience: Int,
     val cries: Cries,
-
-    // Abilities (e.g., Overgrow, Chlorophyll)
-    val abilities: List<PokemonAbility>,
-
-    // Additional species-related fields
-    val gender_rate: Int,          // -1 = genderless, 0–8 = female rate in 1/8 steps
-    val hatch_counter: Int,        // Number of cycles needed to hatch (×255 = steps)
-    val egg_groups: List<EggGroup> // Breeding groups the Pokémon belongs to
+    val abilities: List<String>,
+    val genderRate: Int,
+    val hatchCounter: Int,
+    val eggGroups: List<String>
 )
 
-data class Cries (
+data class Stat(
+    val name: String,
+    val value: Int
+)
+
+data class Cries(
     val latest: String,
     val legacy: String
-)
-
-data class Sprites(
-    val front_default: String
-)
-
-data class PokemonTypeSlot(
-    val slot: Int, val type: TypeInfo
-)
-
-data class TypeInfo(
-    val name: PokemonType
-)
-
-data class PokemonStat(
-    val base_stat: Int, val stat: StatInfo
-)
-
-data class StatInfo(
-    val name: String // Examples: "hp", "attack", "defense"
-)
-
-data class PokemonAbility(
-    val ability: AbilityInfo, val is_hidden: Boolean, val slot: Int
-)
-
-data class AbilityInfo(
-    val name: String, val url: String
-)
-
-data class EggGroup(
-    val name: String, val url: String
 )

--- a/app/src/main/java/com/example/tibiaclone/domain/model/fake/FakePokemon.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/model/fake/FakePokemon.kt
@@ -1,59 +1,29 @@
 package com.example.tibiaclone.domain.model.fake
 
-import com.example.tibiaclone.domain.model.*
+import com.example.tibiaclone.domain.model.Cries
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.model.PokemonType
+import com.example.tibiaclone.domain.model.Stat
 
 val fakePokemon = Pokemon(
     id = 1,
     name = "bulbasaur",
     height = 7,
     weight = 69,
-    sprites = Sprites(
-        front_default = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png"
-    ),
-    types = listOf(
-        PokemonTypeSlot(
-            slot = 1,
-            type = TypeInfo(name = PokemonType.Grass)
-        ),
-        PokemonTypeSlot(
-            slot = 2,
-            type = TypeInfo(name = PokemonType.Poison)
-        )
-    ),
+    imageUrl = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
+    types = listOf(PokemonType.Grass, PokemonType.Poison),
     stats = listOf(
-        PokemonStat(base_stat = 45, stat = StatInfo("hp")),
-        PokemonStat(base_stat = 49, stat = StatInfo("attack")),
-        PokemonStat(base_stat = 49, stat = StatInfo("defense")),
-        PokemonStat(base_stat = 65, stat = StatInfo("special-attack")),
-        PokemonStat(base_stat = 65, stat = StatInfo("special-defense")),
-        PokemonStat(base_stat = 45, stat = StatInfo("speed"))
+        Stat("hp", 45),
+        Stat("attack", 49),
+        Stat("defense", 49),
+        Stat("special-attack", 65),
+        Stat("special-defense", 65),
+        Stat("speed", 45)
     ),
-    base_experience = 64,
-
-    abilities = listOf(
-        PokemonAbility(
-            ability = AbilityInfo(
-                name = "overgrow",
-                url = "https://pokeapi.co/api/v2/ability/65/"
-            ),
-            is_hidden = false,
-            slot = 1
-        ),
-        PokemonAbility(
-            ability = AbilityInfo(
-                name = "chlorophyll",
-                url = "https://pokeapi.co/api/v2/ability/34/"
-            ),
-            is_hidden = true,
-            slot = 3
-        )
-    ),
-
-    gender_rate = 1, // 12.5% female, 87.5% male
-    hatch_counter = 20, // (20 + 1) * 255 = 5355 steps to hatch
-    egg_groups = listOf(
-        EggGroup(name = "monster", url = "https://pokeapi.co/api/v2/egg-group/1/"),
-        EggGroup(name = "grass", url = "https://pokeapi.co/api/v2/egg-group/7/")
-    ),
-    cries = Cries(latest = "lol", legacy = "lol")
+    baseExperience = 64,
+    cries = Cries(latest = "", legacy = ""),
+    abilities = listOf("overgrow", "chlorophyll"),
+    genderRate = 1,
+    hatchCounter = 20,
+    eggGroups = listOf("monster", "grass")
 )

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
@@ -177,7 +177,7 @@ fun TopSection(pokemon: Pokemon, modifier: Modifier, goBack: () -> Unit) {
                     )
                     Row {
                         pokemon.types.forEach {
-                            TypeBox(pokemon = pokemon, pokemonType = it.type.name)
+                            TypeBox(pokemon = pokemon, pokemonType = it)
                         }
                     }
                 }
@@ -252,7 +252,7 @@ fun BottomSection(
 
 @Composable
 fun AboutSection(pokemon: Pokemon) {
-    StatsLines("Species", pokemon.types[0].type.name.name)
+    StatsLines("Species", pokemon.types[0].name)
     StatsLines(
         "Height",
         "${pokemon.height.toString()}''  (${convertFeetToMetersAndCentimeters(pokemon.height)}m) "
@@ -262,7 +262,7 @@ fun AboutSection(pokemon: Pokemon) {
     )
     //MultipleStatsLines("Abilities", pokemon)
     StatsLines(
-        "Ability", pokemon.abilities[0].ability.name.replaceFirstChar { it.uppercase() })
+        "Ability", pokemon.abilities[0].replaceFirstChar { it.uppercase() })
 
     Spacer(Modifier.height(15.dp))
 
@@ -270,7 +270,7 @@ fun AboutSection(pokemon: Pokemon) {
     Text("Breeding", fontWeight = FontWeight.Bold)
     Spacer(Modifier.height(10.dp))
     StatsLines(
-        "Gender", "♂ ${(8 - pokemon.gender_rate) * 12.5} ♀ ${pokemon.gender_rate * 12.5}%"
+        "Gender", "♂ ${(8 - pokemon.genderRate) * 12.5} ♀ ${pokemon.genderRate * 12.5}%"
     )
     StatsLines("Eggs Groups", "Monster")
     StatsLines("Egg Cycle", (pokemon.height.toInt() * 0.4 * 10).toInt().toString())
@@ -278,21 +278,21 @@ fun AboutSection(pokemon: Pokemon) {
 
 @Composable
 fun StatsSection(pokemon: Pokemon) {
-    StatusGraphs(title = "HP", value = pokemon.stats[0].base_stat, barColor = Color(0xfffc6c6d))
+    StatusGraphs(title = "HP", value = pokemon.stats[0].value, barColor = Color(0xfffc6c6d))
     Spacer(modifier = Modifier.height(10.dp))
 
 
-    StatusGraphs(title = "Attack", value = pokemon.stats[1].base_stat, barColor = Color(0xff5eb382))
+    StatusGraphs(title = "Attack", value = pokemon.stats[1].value, barColor = Color(0xff5eb382))
     Spacer(modifier = Modifier.height(10.dp))
     StatusGraphs(
-        title = "Defense", value = pokemon.stats[2].base_stat, barColor = Color(0xfffc6c6d)
+        title = "Defense", value = pokemon.stats[2].value, barColor = Color(0xfffc6c6d)
     )
     Spacer(modifier = Modifier.height(10.dp))
-    StatusGraphs(title = "Sp.Atk", value = pokemon.stats[3].base_stat, barColor = Color(0xff5eb382))
+    StatusGraphs(title = "Sp.Atk", value = pokemon.stats[3].value, barColor = Color(0xff5eb382))
     Spacer(modifier = Modifier.height(10.dp))
-    StatusGraphs(title = "Sp.Def", value = pokemon.stats[4].base_stat, barColor = Color(0xfffc6c6d))
+    StatusGraphs(title = "Sp.Def", value = pokemon.stats[4].value, barColor = Color(0xfffc6c6d))
     Spacer(modifier = Modifier.height(10.dp))
-    StatusGraphs(title = "Speed", value = pokemon.stats[5].base_stat, barColor = Color(0xff5eb382))
+    StatusGraphs(title = "Speed", value = pokemon.stats[5].value, barColor = Color(0xff5eb382))
     Spacer(modifier = Modifier.height(10.dp))
     //StatusGraphs(title = "Total", value = pokemon.stats[6].base_stat, barColor = Color(0xfffc6c6d))
     Spacer(Modifier.height(15.dp))
@@ -405,13 +405,13 @@ fun MultipleStatsLines(title: String, pokemon: Pokemon) {
 
                 if (index + 1 < pokemon.abilities.size) {
                     Text(
-                        text = "${ability.ability.name.replaceFirstChar { it.uppercase() }}, ",
+                        text = "${ability.replaceFirstChar { it.uppercase() }}, ",
                         fontWeight = FontWeight.SemiBold,
                         color = Color.Black,
                     )
                 } else {
                     Text(
-                        text = "${ability.ability.name.replaceFirstChar { it.uppercase() }}",
+                        text = ability.replaceFirstChar { it.uppercase() },
                         fontWeight = FontWeight.SemiBold,
                         color = Color.Black,
                     )

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
@@ -72,9 +72,10 @@ fun PokemonBox(
                 modifier = Modifier.zIndex(2f)
             )
             pokemon.types.forEach {
-
                 TypeBox(
-                    pokemon = pokemon, pokemonType = it.type.name, modifier = Modifier
+                    pokemon = pokemon,
+                    pokemonType = it,
+                    modifier = Modifier
                         .align(Alignment.Start)
                         .offset(x = -(15.dp))
                 )

--- a/app/src/main/java/com/example/tibiaclone/utils/ColorsByType.kt
+++ b/app/src/main/java/com/example/tibiaclone/utils/ColorsByType.kt
@@ -9,7 +9,7 @@ import com.example.tibiaclone.domain.model.PokemonType
 fun getPokemonBackgroundColor(pokemon: Pokemon): Color {
 
 
-    return when (pokemon.types[0].type.name) {
+    return when (pokemon.types[0]) {
         PokemonType.Normal -> Color(0xFF9FA19F)
         PokemonType.Fire -> Color(0xFFE52828)
         PokemonType.Water -> Color(0xFF2A81EF)


### PR DESCRIPTION
## Summary
- define a `PokemonDto` to mirror the PokeAPI structure
- create a mapper to convert `PokemonDto` to the new cleaned `Pokemon` domain model
- refactor repository and API to use DTOs
- update UI and utilities to the new `Pokemon` structure
- adjust fake Pokemon data for tests/demos

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5a119b4832ea96424f8804b054e