### PR TITLE
Implement favorites with DataStore

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
@@ -1,7 +1,38 @@
 package com.example.tibiaclone.data.repository
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.example.tibiaclone.domain.repository.FavoritesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
-class FavoritesRepositoryImpl : FavoritesRepository {
-    // TODO: implement favorites persistence using DataStore or Room
+/** Implementation of [FavoritesRepository] backed by Jetpack DataStore. */
+class FavoritesRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : FavoritesRepository {
+
+    private val favoritesKey = stringSetPreferencesKey("favorite_pokemon_ids")
+
+    override val favoriteIds: Flow<Set<Int>> = dataStore.data.map { prefs ->
+        prefs[favoritesKey]?.mapNotNull { it.toIntOrNull() }?.toSet() ?: emptySet()
+    }
+
+    override suspend fun toggleFavorite(pokemonId: Int) {
+        dataStore.edit { prefs ->
+            val current = prefs[favoritesKey]?.toMutableSet() ?: mutableSetOf()
+            val idString = pokemonId.toString()
+            if (current.contains(idString)) {
+                current.remove(idString)
+            } else {
+                current.add(idString)
+            }
+            prefs[favoritesKey] = current
+        }
+    }
+
+    override fun isFavorite(pokemonId: Int): Flow<Boolean> =
+        favoriteIds.map { it.contains(pokemonId) }
 }

--- a/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
@@ -4,11 +4,19 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.example.tibiaclone.data.remote.api.PokemonApi
 import com.example.tibiaclone.data.repository.PokemonRepositoryImpl
+import com.example.tibiaclone.data.repository.FavoritesRepositoryImpl
+import com.example.tibiaclone.domain.repository.FavoritesRepository
 import com.example.tibiaclone.domain.repository.PokemonRepository
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Singleton
 
 @Module //This class will provide objects
@@ -28,5 +36,18 @@ object NetworkModule {
     @Singleton
     fun providePokemonRepository(pokemonApi: PokemonApi): PokemonRepository {
         return PokemonRepositoryImpl(pokemonApi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("favorites") }
+        )
+
+    @Provides
+    @Singleton
+    fun provideFavoritesRepository(dataStore: DataStore<Preferences>): FavoritesRepository {
+        return FavoritesRepositoryImpl(dataStore)
     }
 }

--- a/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
@@ -1,5 +1,17 @@
 package com.example.tibiaclone.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository responsible for persisting and exposing the list of favorited Pokémon ids.
+ */
 interface FavoritesRepository {
-    // TODO: define methods for managing favorites
+    /** Flow containing the ids of the currently favorited Pokémon. */
+    val favoriteIds: Flow<Set<Int>>
+
+    /** Toggle the favorite state for the given [pokemonId]. */
+    suspend fun toggleFavorite(pokemonId: Int)
+
+    /** Observe whether the given [pokemonId] is marked as favorite. */
+    fun isFavorite(pokemonId: Int): Flow<Boolean>
 }

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
 import androidx.compose.material.icons.filled.Volcano
@@ -47,6 +48,7 @@ import com.example.tibiaclone.ui.theme.SetStatusBarColor
 import com.example.tibiaclone.utils.getPokemonBackgroundColor
 import com.example.tibiaclone.utils.getPrettyRemoteSprites
 import com.example.tibiaclone.ui.viewmodel.DetailViewModel
+import com.example.tibiaclone.ui.viewmodel.FavoritesViewModel
 import com.example.tibiaclone.utils.*;
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,10 +56,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun DetailsScreen(
-    pokemonId: Int, navController: NavHostController, viewModel: DetailViewModel = hiltViewModel()
+    pokemonId: Int,
+    navController: NavHostController,
+    viewModel: DetailViewModel = hiltViewModel(),
+    favoritesViewModel: FavoritesViewModel = hiltViewModel()
 ) {
     val selectedPokemon by viewModel.selectedPokemon.collectAsState()
     val isAboutTabSelected by viewModel.isAboutTabSelected.collectAsState();
+    val isFavorite by favoritesViewModel.isFavorite(pokemonId).collectAsState(initial = false)
 
     SetStatusBarColor(
         color = getPokemonBackgroundColor(pokemon = selectedPokemon!!),
@@ -80,7 +86,9 @@ fun DetailsScreen(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(top = 15.dp),
-                    goBack = { navController.popBackStack() }
+                    goBack = { navController.popBackStack() },
+                    isFavorite = isFavorite,
+                    onToggleFavorite = { favoritesViewModel.toggleFavorite(pokemon.id) }
                 )
                 BottomSection(
                     pokemon = pokemon,
@@ -123,7 +131,13 @@ fun DetailsScreen(
 }
 
 @Composable
-fun TopSection(pokemon: Pokemon, modifier: Modifier, goBack: () -> Unit) {
+fun TopSection(
+    pokemon: Pokemon,
+    modifier: Modifier,
+    goBack: () -> Unit,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit
+) {
     Box(
         modifier = modifier
             .background(getPokemonBackgroundColor(pokemon))
@@ -149,10 +163,12 @@ fun TopSection(pokemon: Pokemon, modifier: Modifier, goBack: () -> Unit) {
                             goBack()
                         })
                 Icon(
-                    Icons.Filled.Favorite,
+                    if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                     contentDescription = "Favorite",
                     tint = Color.White,
-                    modifier = Modifier.size(30.dp)
+                    modifier = Modifier
+                        .size(30.dp)
+                        .clickable { onToggleFavorite() }
                 )
             }
 

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
@@ -1,16 +1,51 @@
 package com.example.tibiaclone.ui.screens.favorites
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Button
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tibiaclone.ui.screens.home.PokemonBox
+import com.example.tibiaclone.ui.screens.home.Subtitle
+import com.example.tibiaclone.ui.viewmodel.FavoritesViewModel
 
 @Composable
-fun FavoritesScreen(onPokemonClick: (Int) -> Unit) {
-    Column {
-        Text("Favorites")
-        Button(onClick = { onPokemonClick(25) }) {
-            Text("Go to Favorite: Pikachu")
+fun FavoritesScreen(
+    onPokemonClick: (Int) -> Unit,
+    viewModel: FavoritesViewModel = hiltViewModel()
+) {
+    val favorites by viewModel.favoritePokemons.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Subtitle("Favorites")
+        Spacer(modifier = Modifier.height(20.dp))
+
+        if (favorites.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("No favorites yet")
+            }
+        } else {
+            LazyColumn(modifier = Modifier.padding(end = 10.dp)) {
+                items(favorites.chunked(2)) { rowItems ->
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        rowItems.forEach { pokemon ->
+                            PokemonBox(
+                                pokemon = pokemon,
+                                onCLick = { onPokemonClick(pokemon.id) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(2.dp)
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
@@ -1,0 +1,40 @@
+package com.example.tibiaclone.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.repository.FavoritesRepository
+import com.example.tibiaclone.domain.repository.PokemonRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoritesViewModel @Inject constructor(
+    private val favoritesRepository: FavoritesRepository,
+    private val pokemonRepository: PokemonRepository
+) : ViewModel() {
+
+    private val _favoritePokemons = MutableStateFlow<List<Pokemon>>(emptyList())
+    val favoritePokemons: StateFlow<List<Pokemon>> = _favoritePokemons
+
+    init {
+        viewModelScope.launch {
+            favoritesRepository.favoriteIds.collect { ids ->
+                val pokemons = ids.mapNotNull { id ->
+                    pokemonRepository.getPokemonFromCache(id) ?: runCatching {
+                        pokemonRepository.getPokemon(id)
+                    }.getOrNull()
+                }
+                _favoritePokemons.value = pokemons
+            }
+        }
+    }
+
+    fun toggleFavorite(id: Int) {
+        viewModelScope.launch { favoritesRepository.toggleFavorite(id) }
+    }
+
+    fun isFavorite(id: Int): Flow<Boolean> = favoritesRepository.isFavorite(id)
+}


### PR DESCRIPTION
## Summary
- implement persistence for favorites using DataStore
- expose favorite management via `FavoritesRepository`
- provide repository and datastore through DI
- add `FavoritesViewModel` and wire it into `FavoritesScreen` and `DetailsScreen`
- update screens to toggle favorites and render correct icon

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841e84162fc832ebe4d58f48b66b172