### PR TITLE
Fix Pokemon DTO defaults

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonDto.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/remote/model/PokemonDto.kt
@@ -11,11 +11,11 @@ data class PokemonDto(
     val types: List<PokemonTypeSlotDto>,
     val stats: List<PokemonStatDto>,
     val base_experience: Int,
-    val cries: CriesDto,
-    val abilities: List<PokemonAbilityDto>,
-    val gender_rate: Int,
-    val hatch_counter: Int,
-    val egg_groups: List<EggGroupDto>
+    val cries: CriesDto = CriesDto("", ""),
+    val abilities: List<PokemonAbilityDto> = emptyList(),
+    val gender_rate: Int = 0,
+    val hatch_counter: Int = 0,
+    val egg_groups: List<EggGroupDto> = emptyList()
 )
 
 data class CriesDto(


### PR DESCRIPTION
## Summary
- prevent parsing errors by setting default values for optional fields in `PokemonDto`

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb56bf68832eb8d933c5d00d504c