### PR TITLE
Implement Favorites screen with full-width items

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
@@ -1,16 +1,55 @@
 package com.example.tibiaclone.ui.screens.favorites
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Button
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tibiaclone.ui.screens.home.PokemonBox
+import com.example.tibiaclone.ui.screens.home.Subtitle
+import com.example.tibiaclone.ui.theme.SetStatusBarColor
+import com.example.tibiaclone.ui.viewmodel.FavoritesViewModel
 
 @Composable
-fun FavoritesScreen(onPokemonClick: (Int) -> Unit) {
-    Column {
-        Text("Favorites")
-        Button(onClick = { onPokemonClick(25) }) {
-            Text("Go to Favorite: Pikachu")
+fun FavoritesScreen(onPokemonClick: (Int) -> Unit, viewModel: FavoritesViewModel = hiltViewModel()) {
+    SetStatusBarColor(color = Color.White, darkIcons = true)
+
+    val pokemonList by viewModel.pokemonList.collectAsState()
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp.dp
+    val commonMargin = screenWidthDp.value * 0.05
+
+    if (pokemonList.isNotEmpty()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Subtitle("Favorites")
+            Spacer(modifier = Modifier.height(20.dp))
+            LazyColumn(modifier = Modifier.padding(end = 10.dp)) {
+                item { Spacer(modifier = Modifier.width(commonMargin.dp)) }
+                items(pokemonList) { pokemon ->
+                    PokemonBox(
+                        pokemon = pokemon,
+                        onCLick = { onPokemonClick(pokemon.id) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp)
+                    )
+                }
+            }
+        }
+    } else {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
@@ -1,0 +1,26 @@
+package com.example.tibiaclone.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tibiaclone.domain.model.Pokemon
+import com.example.tibiaclone.domain.repository.PokemonRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoritesViewModel @Inject constructor(
+    private val pokemonRepository: PokemonRepository
+) : ViewModel() {
+
+    private val _pokemonList = MutableStateFlow<List<Pokemon>>(emptyList())
+    val pokemonList: StateFlow<List<Pokemon>> = _pokemonList
+
+    init {
+        viewModelScope.launch {
+            _pokemonList.value = pokemonRepository.getListOfPokemons(20)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FavoritesViewModel` to fetch pokémon data
- redesign `FavoritesScreen` to match HomeScreen style while showing one item per row

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841f45b9b28832e8cf362a7a793e9a0