### PR TITLE
Add favorites storage using DataStore

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/tibiaclone/data/repository/FavoritesRepositoryImpl.kt
@@ -1,7 +1,55 @@
 package com.example.tibiaclone.data.repository
 
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.example.tibiaclone.domain.model.Pokemon
 import com.example.tibiaclone.domain.repository.FavoritesRepository
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
-class FavoritesRepositoryImpl : FavoritesRepository {
-    // TODO: implement favorites persistence using DataStore or Room
+private val Context.dataStore by preferencesDataStore(name = "favorites_prefs")
+
+class FavoritesRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : FavoritesRepository {
+
+    private object Keys {
+        val FAVORITES = stringPreferencesKey("favorites_list")
+    }
+
+    private val gson = Gson()
+    private val listType = object : TypeToken<List<Pokemon>>() {}.type
+
+    override val favorites: Flow<List<Pokemon>> = context.dataStore.data.map { prefs ->
+        prefs[Keys.FAVORITES]?.let { json ->
+            gson.fromJson<List<Pokemon>>(json, listType)
+        } ?: emptyList()
+    }
+
+    override suspend fun getPokemon(id: Int): Pokemon? {
+        return favorites.first().find { it.id == id }
+    }
+
+    override suspend fun addPokemon(pokemon: Pokemon) {
+        context.dataStore.edit { prefs ->
+            val current = prefs[Keys.FAVORITES]?.let { gson.fromJson<List<Pokemon>>(it, listType) } ?: emptyList()
+            if (current.none { it.id == pokemon.id }) {
+                prefs[Keys.FAVORITES] = gson.toJson(current + pokemon)
+            }
+        }
+    }
+
+    override suspend fun removePokemon(id: Int) {
+        context.dataStore.edit { prefs ->
+            val current = prefs[Keys.FAVORITES]?.let { gson.fromJson<List<Pokemon>>(it, listType) } ?: emptyList()
+            prefs[Keys.FAVORITES] = gson.toJson(current.filter { it.id != id })
+        }
+    }
 }

--- a/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/tibiaclone/di/NetworkModule.kt
@@ -1,12 +1,16 @@
 package com.example.tibiaclone.di
 
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import com.example.tibiaclone.data.remote.api.PokemonApi
 import com.example.tibiaclone.data.repository.PokemonRepositoryImpl
+import com.example.tibiaclone.data.repository.FavoritesRepositoryImpl
 import com.example.tibiaclone.domain.repository.PokemonRepository
+import com.example.tibiaclone.domain.repository.FavoritesRepository
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -28,5 +32,13 @@ object NetworkModule {
     @Singleton
     fun providePokemonRepository(pokemonApi: PokemonApi): PokemonRepository {
         return PokemonRepositoryImpl(pokemonApi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideFavoritesRepository(
+        @ApplicationContext context: Context
+    ): FavoritesRepository {
+        return FavoritesRepositoryImpl(context)
     }
 }

--- a/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/tibiaclone/domain/repository/FavoritesRepository.kt
@@ -1,5 +1,26 @@
 package com.example.tibiaclone.domain.repository
 
+import com.example.tibiaclone.domain.model.Pokemon
+import kotlinx.coroutines.flow.Flow
+
 interface FavoritesRepository {
-    // TODO: define methods for managing favorites
+    /**
+     * Flow containing the current list of favorite pokemons.
+     */
+    val favorites: Flow<List<Pokemon>>
+
+    /**
+     * Returns a pokemon from the favorites list or `null` if it's not present.
+     */
+    suspend fun getPokemon(id: Int): Pokemon?
+
+    /**
+     * Adds the given [pokemon] to the favorites list.
+     */
+    suspend fun addPokemon(pokemon: Pokemon)
+
+    /**
+     * Removes the pokemon with the provided [id] from the favorites list.
+     */
+    suspend fun removePokemon(id: Int)
 }

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/details/DetailsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
 import androidx.compose.material.icons.filled.Volcano
@@ -57,7 +58,8 @@ fun DetailsScreen(
     pokemonId: Int, navController: NavHostController, viewModel: DetailViewModel = hiltViewModel()
 ) {
     val selectedPokemon by viewModel.selectedPokemon.collectAsState()
-    val isAboutTabSelected by viewModel.isAboutTabSelected.collectAsState();
+    val isAboutTabSelected by viewModel.isAboutTabSelected.collectAsState()
+    val isFavorite by viewModel.isFavorite.collectAsState()
 
     SetStatusBarColor(
         color = getPokemonBackgroundColor(pokemon = selectedPokemon!!),
@@ -149,10 +151,12 @@ fun TopSection(pokemon: Pokemon, modifier: Modifier, goBack: () -> Unit) {
                             goBack()
                         })
                 Icon(
-                    Icons.Filled.Favorite,
+                    imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                     contentDescription = "Favorite",
                     tint = Color.White,
-                    modifier = Modifier.size(30.dp)
+                    modifier = Modifier
+                        .size(30.dp)
+                        .clickable { viewModel.toggleFavorite() }
                 )
             }
 

--- a/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/viewmodel/FavoritesViewModel.kt
@@ -3,7 +3,7 @@ package com.example.tibiaclone.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.tibiaclone.domain.model.Pokemon
-import com.example.tibiaclone.domain.repository.PokemonRepository
+import com.example.tibiaclone.domain.repository.FavoritesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FavoritesViewModel @Inject constructor(
-    private val pokemonRepository: PokemonRepository
+    private val favoritesRepository: FavoritesRepository
 ) : ViewModel() {
 
     private val _pokemonList = MutableStateFlow<List<Pokemon>>(emptyList())
@@ -20,7 +20,13 @@ class FavoritesViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            _pokemonList.value = pokemonRepository.getListOfPokemons(20)
+            favoritesRepository.favorites.collect { list ->
+                _pokemonList.value = list
+            }
         }
+    }
+
+    fun removePokemon(id: Int) {
+        viewModelScope.launch { favoritesRepository.removePokemon(id) }
     }
 }


### PR DESCRIPTION
## Summary
- implement `FavoritesRepository` interface
- implement persistence layer with DataStore
- provide new repository via Hilt
- update view models and UI to toggle favorites

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841fae0c8c8832e9898d3d8a7dc89ab