### PR TITLE
Prevent repeated tap navigation

### DIFF
--- a/app/src/main/java/com/example/tibiaclone/ui/navigation/FavoritesNavHost.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/navigation/FavoritesNavHost.kt
@@ -13,9 +13,12 @@ fun FavoritesNavHost() {
 
     NavHost(navController = navController, startDestination = "favorites") {
         composable("favorites") {
-            FavoritesScreen (onPokemonClick = { id ->
-                navController.navigate("details/$id")
-            })
+            FavoritesScreen(
+                navController = navController,
+                onPokemonClick = { id ->
+                    navController.navigate("details/$id")
+                }
+            )
         }
         composable("details/{pokemonId}") { backStackEntry ->
             val pokemonId = backStackEntry.arguments?.getString("pokemonId")?.toIntOrNull()

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/favorites/FavoritesScreen.kt
@@ -17,12 +17,20 @@ import com.example.tibiaclone.ui.screens.home.PokemonBox
 import com.example.tibiaclone.ui.screens.home.Subtitle
 import com.example.tibiaclone.ui.theme.SetStatusBarColor
 import com.example.tibiaclone.ui.viewmodel.FavoritesViewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 
 @Composable
-fun FavoritesScreen(onPokemonClick: (Int) -> Unit, viewModel: FavoritesViewModel = hiltViewModel()) {
+fun FavoritesScreen(
+    navController: NavHostController,
+    onPokemonClick: (Int) -> Unit,
+    viewModel: FavoritesViewModel = hiltViewModel()
+) {
     SetStatusBarColor(color = Color.White, darkIcons = true)
 
     val pokemonList by viewModel.pokemonList.collectAsState()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val isFavoritesRoute = navBackStackEntry?.destination?.route == "favorites"
     val configuration = LocalConfiguration.current
     val screenWidthDp = configuration.screenWidthDp.dp
     val commonMargin = screenWidthDp.value * 0.05
@@ -37,6 +45,7 @@ fun FavoritesScreen(onPokemonClick: (Int) -> Unit, viewModel: FavoritesViewModel
                     PokemonBox(
                         pokemon = pokemon,
                         onCLick = { onPokemonClick(pokemon.id) },
+                        enabled = isFavoritesRoute,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 2.dp)

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import com.example.tibiaclone.ui.theme.SetStatusBarColor
 
 
@@ -26,6 +27,9 @@ fun HomeScreen(
 ) {
 
     SetStatusBarColor(color = Color.White, darkIcons = true)
+
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val isHomeRoute = navBackStackEntry?.destination?.route == "home"
 
     val pokemonList by viewModel.pokemonList.collectAsState()
 
@@ -57,6 +61,7 @@ fun HomeScreen(
                                     Log.d("Debug", it.toString())
                                     navController.navigate("details/${pokemon.id}");
                                 },
+                                enabled = isHomeRoute,
                                 modifier = Modifier
                                     .weight(1f)
                                     .padding(2.dp)

--- a/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
+++ b/app/src/main/java/com/example/tibiaclone/ui/screens/home/PokemonBox.kt
@@ -40,7 +40,10 @@ import com.example.tibiaclone.utils.getPrettyRemoteSprites
 
 @Composable
 fun PokemonBox(
-    pokemon: Pokemon, modifier: Modifier = Modifier, onCLick: (Pokemon) -> Unit
+    pokemon: Pokemon,
+    modifier: Modifier = Modifier,
+    onCLick: (Pokemon) -> Unit,
+    enabled: Boolean = true
 ) {
     val borderGray = colorResource(id = R.color.border_gray)
 
@@ -55,7 +58,7 @@ fun PokemonBox(
             )
             .border(width = 1.dp, color = borderGray, shape = RoundedCornerShape(8.dp))
             .clipToBounds() // overflow -> hidden
-            .clickable {
+            .clickable(enabled = enabled) {
                 onCLick(pokemon)
             }
             .padding(5.dp)) {


### PR DESCRIPTION
## Summary
- disable PokemonBox when not on home or favorites route
- pass navController to FavoritesScreen
- track current route in HomeScreen and FavoritesScreen

## Testing
- `./gradlew test --no-daemon` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68430f9cd92c832e842ec0b94cfbab61